### PR TITLE
Closes #102: information log about configuration reloading

### DIFF
--- a/alignak_module_backend/etc/arbiter/modules/mod-alignak_backend_broker.cfg
+++ b/alignak_module_backend/etc/arbiter/modules/mod-alignak_backend_broker.cfg
@@ -18,4 +18,11 @@ define module {
     # Number of processes used by the backend client to get data from backend.
     # For example, if you define 4, it will be get data in 4 processes and so faster.
     #client_processes        1
+
+    # Number of seconds (minimum) between two configuration reloading
+    # When the broker receives its configuration from several schedulers (multi-realms)
+    # this will avoid reloading all the host/service/user objects several times (once for each
+    # received configuration)
+    # Default is 5 minutes
+    # load_protect_delay  300
 }

--- a/test/test_broker_common.py
+++ b/test/test_broker_common.py
@@ -201,7 +201,7 @@ class TestBrokerCommon(unittest2.TestCase):
     def test_01_get_refs_host(self):
         """Get hosts references"""
         # Default reload protection delay
-        self.assertEqual(self.brokmodule.load_protect_delay, 3600)
+        self.assertEqual(self.brokmodule.load_protect_delay, 300)
 
         now = int(time.time())
         # First call loads the corresponding objects
@@ -235,7 +235,7 @@ class TestBrokerCommon(unittest2.TestCase):
     def test_02_get_refs_service(self):
         """Get services references"""
         # Default reload protection delay
-        self.assertEqual(self.brokmodule.load_protect_delay, 3600)
+        self.assertEqual(self.brokmodule.load_protect_delay, 300)
 
         now = int(time.time())
         # First call loads the corresponding objects
@@ -275,7 +275,7 @@ class TestBrokerCommon(unittest2.TestCase):
     def test_03_get_refs_users(self):
         """Get users references"""
         # Default reload protection delay
-        self.assertEqual(self.brokmodule.load_protect_delay, 3600)
+        self.assertEqual(self.brokmodule.load_protect_delay, 300)
 
         now = int(time.time())
         # First call loads the corresponding objects


### PR DESCRIPTION
Set the load_protect_delay (5 minutes) parameter in the broker module configuration file